### PR TITLE
update MacOS and Windows download URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Your private keys are stored locally only and are properly encrypted with a user
 Off-chain information (such as the Block Producer standard) are fetched via a proxy server provided by EOS Rio, to avoid malformed json data and third-party servers misconfigurations. 
 
 ## Download a pre-compiled build
-- [Windows](https://github.com/eosrio/simpleos/releases/download/v0.3.5/simpleos-setup-0.3.5.exe)
-- [MacOS](https://github.com/eosrio/simpleos/releases/download/v0.3.5/simpleos-0.3.5-mac.zip)
+- [Windows](https://github.com/eosrio/simpleos/releases/download/v0.3.6/simpleos-setup-0.3.6.exe)
+- [MacOS](https://github.com/eosrio/simpleos/releases/download/v0.3.6/simpleos-0.3.6.dmg)
 - [Linux](https://github.com/eosrio/simpleos/releases/download/v0.3.5/simpleos_0.3.5_amd64.deb)
 
 ## Build it yourself


### PR DESCRIPTION
As some people prefer to download it from github (as indicates in the steemit article) I think it would be good to keep the download urls in the READM file uptodate.

If you guys think it is not necessary to update this right now, please close this PR.